### PR TITLE
[redesign] Home page skeleton, grid system test

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -49,6 +49,7 @@
     "react-diff-view": "^2.4.4",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",
+    "react-grid-system": "^7.3.1",
     "react-markdown": "^5.0.3",
     "react-player": "^1.11.1",
     "react-visibility-sensor": "^5.1.0",

--- a/docs/pages/test-design/home.mdx
+++ b/docs/pages/test-design/home.mdx
@@ -5,29 +5,32 @@ hideTOC: true
 ---
 
 import { Container, Row } from 'react-grid-system';
-import { H4, BOLD } from '~/ui/components/text';
-import { GridCell } from '~/ui/components/home/GridCell';
 import { colors } from '@expo/styleguide';
+
+import { APIGridCell, GridCell } from '~/ui/components/home/GridCell';
+import { H3, P } from '~/ui/components/text';
+import { SDKIcon } from "~/ui/foundations/icons";
 
 <!-- https://github.com/sealninja/react-grid-system/issues/175 -->
 <Container fluid style={{ paddingLeft: -15, paddingRight: -15 }}>
   <Row>
     <GridCell md={9} style={{ backgroundColor: '#F0EBFF' }}>
-      <H4>Create a universal iOS, Android, and web photo sharing app</H4>
+      <H3>Create a universal iOS, Android, and web photo sharing app</H3>
     </GridCell>
     <GridCell md={3} style={{ backgroundColor: colors.gray["1000"]}}>
-      <H4 style={{ color: colors.gray["000"]}}>Quick Start</H4>
+      <H3 style={{ color: colors.gray["000"]}}>Quick Start</H3>
     </GridCell>
   </Row>
   <Row>
     <GridCell md={4} style={{ backgroundColor: colors.blue["000"] }}>
-      <H4>Try Snack</H4>
+      <H3>Try Snack</H3>
+      <P>Snack lets you try Expo with zero local setup.</P>
     </GridCell>
     <GridCell md={4} style={{ backgroundColor: colors.orange["100"] }}>
-      <H4>Learn Expo on Codecademy</H4>
+      <H3>Learn Expo on Codecademy</H3>
     </GridCell>
     <GridCell md={4} style={{ backgroundColor: colors.green["000"] }}>
-      <H4>Why and why not Expo</H4>
+      <H3>Why and why not Expo</H3>
     </GridCell>
   </Row>
 </Container>
@@ -38,10 +41,10 @@ Expo supplies over 192 APIs in the SDK. You can also create your own.
 
 <Container fluid style={{ paddingLeft: -15, paddingRight: -15 }}>
   <Row>
-    <GridCell md={3}><BOLD>Maps</BOLD></GridCell>
-    <GridCell md={3}><BOLD>Camera</BOLD></GridCell>
-    <GridCell md={3}><BOLD>Notifications</BOLD></GridCell>
-    <GridCell md={3}><BOLD>View all APIs</BOLD></GridCell>
+    <APIGridCell md={3} title="Maps" link="/versions/latest/sdk/map-view" icon={<SDKIcon size={58} />} />
+    <APIGridCell md={3} title="Camera" link="/versions/latest/sdk/camera" icon={<SDKIcon size={58} />} />
+    <APIGridCell md={3} title="Notifications" link="/versions/latest/sdk/notifications" icon={<SDKIcon size={58} />} />
+    <APIGridCell md={3} title="View all APIs" link="/versions/latest/sdk/" icon={<SDKIcon size={58} />} />
   </Row>
 </Container>
 

--- a/docs/pages/test-design/home.mdx
+++ b/docs/pages/test-design/home.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 import { Container, Row } from 'react-grid-system';
 import { colors } from '@expo/styleguide';
 
-import { APIGridCell, GridCell } from '~/ui/components/home/GridCell';
+import { APIGridCell, CommunityGridCell, GridCell } from '~/ui/components/home/GridCell';
 import { H3, P } from '~/ui/components/text';
 import { SDKIcon } from "~/ui/foundations/icons";
 
@@ -17,19 +17,19 @@ import { SDKIcon } from "~/ui/foundations/icons";
     <GridCell md={9} style={{ backgroundColor: '#F0EBFF' }}>
       <H3>Create a universal iOS, Android, and web photo sharing app</H3>
     </GridCell>
-    <GridCell md={3} style={{ backgroundColor: colors.gray["1000"]}}>
-      <H3 style={{ color: colors.gray["000"]}}>Quick Start</H3>
+    <GridCell md={3} style={{ backgroundColor: colors.gray['1000']}}>
+      <H3 style={{ color: colors.gray['000']}}>Quick Start</H3>
     </GridCell>
   </Row>
   <Row>
-    <GridCell md={4} style={{ backgroundColor: colors.blue["000"] }}>
+    <GridCell md={4} style={{ backgroundColor: colors.blue['000'] }}>
       <H3>Try Snack</H3>
       <P>Snack lets you try Expo with zero local setup.</P>
     </GridCell>
-    <GridCell md={4} style={{ backgroundColor: colors.orange["100"] }}>
+    <GridCell md={4} style={{ backgroundColor: colors.orange['100'] }}>
       <H3>Learn Expo on Codecademy</H3>
     </GridCell>
-    <GridCell md={4} style={{ backgroundColor: colors.green["000"] }}>
+    <GridCell md={4} style={{ backgroundColor: colors.green['000'] }}>
       <H3>Why and why not Expo</H3>
     </GridCell>
   </Row>
@@ -51,3 +51,40 @@ Expo supplies over 192 APIs in the SDK. You can also create your own.
 ## Join the community
 
 See the source code, connect with others, and get connected.
+
+<Container fluid style={{ paddingLeft: -15, paddingRight: -15 }}>
+  <Row>
+    <CommunityGridCell
+      md={6}
+      title="GitHub"
+      description="View our SDK, submit a PR, or report an issue."
+      link="https://github.com/expo/expo"
+      icon={<SDKIcon size={20} />}
+    />
+    <CommunityGridCell
+      md={6}
+      title="Discord"
+      description="Join our Discord and chat with other Expo users."
+      link="https://chat.expo.dev"
+      icon={<SDKIcon size={20} />}
+      iconBackground="#3131E8"
+    />
+  </Row>
+  <Row>
+    <CommunityGridCell
+      md={6}
+      title="Twitter"
+      description="Follow Expo on Twitter for news and updates."
+      link="https://twitter.com/expo"
+      icon={<SDKIcon size={20} />}
+      iconBackground="#1E8EF0"
+    />
+    <CommunityGridCell
+      md={6}
+      title="Forums"
+      description="Ask or answer a question on the forums."
+      link="https://forums.expo.dev/"
+      icon={<SDKIcon size={20} />}
+    />
+  </Row>
+</Container>

--- a/docs/pages/test-design/home.mdx
+++ b/docs/pages/test-design/home.mdx
@@ -44,7 +44,7 @@ Expo supplies over 192 APIs in the SDK. You can also create your own.
     <APIGridCell md={3} title="Maps" link="/versions/latest/sdk/map-view" icon={<SDKIcon size={58} />} />
     <APIGridCell md={3} title="Camera" link="/versions/latest/sdk/camera" icon={<SDKIcon size={58} />} />
     <APIGridCell md={3} title="Notifications" link="/versions/latest/sdk/notifications" icon={<SDKIcon size={58} />} />
-    <APIGridCell md={3} title="View all APIs" link="/versions/latest/sdk/" icon={<SDKIcon size={58} />} />
+    <APIGridCell md={3} title="View all APIs" link="/versions/latest/" icon={<SDKIcon size={58} />} />
   </Row>
 </Container>
 

--- a/docs/pages/test-design/home.mdx
+++ b/docs/pages/test-design/home.mdx
@@ -1,0 +1,50 @@
+---
+title: Get started with Expo
+description: Choose how to start the way that matches your learning style.
+hideTOC: true
+---
+
+import { Container, Row } from 'react-grid-system';
+import { H4, BOLD } from '~/ui/components/text';
+import { GridCell } from '~/ui/components/home/GridCell';
+import { colors } from '@expo/styleguide';
+
+<!-- https://github.com/sealninja/react-grid-system/issues/175 -->
+<Container fluid style={{ paddingLeft: -15, paddingRight: -15 }}>
+  <Row>
+    <GridCell md={9} style={{ backgroundColor: '#F0EBFF' }}>
+      <H4>Create a universal iOS, Android, and web photo sharing app</H4>
+    </GridCell>
+    <GridCell md={3} style={{ backgroundColor: colors.gray["1000"]}}>
+      <H4 style={{ color: colors.gray["000"]}}>Quick Start</H4>
+    </GridCell>
+  </Row>
+  <Row>
+    <GridCell md={4} style={{ backgroundColor: colors.blue["000"] }}>
+      <H4>Try Snack</H4>
+    </GridCell>
+    <GridCell md={4} style={{ backgroundColor: colors.orange["100"] }}>
+      <H4>Learn Expo on Codecademy</H4>
+    </GridCell>
+    <GridCell md={4} style={{ backgroundColor: colors.green["000"] }}>
+      <H4>Why and why not Expo</H4>
+    </GridCell>
+  </Row>
+</Container>
+
+## Get the most out of Expo
+
+Expo supplies over 192 APIs in the SDK. You can also create your own.
+
+<Container fluid style={{ paddingLeft: -15, paddingRight: -15 }}>
+  <Row>
+    <GridCell md={3}><BOLD>Maps</BOLD></GridCell>
+    <GridCell md={3}><BOLD>Camera</BOLD></GridCell>
+    <GridCell md={3}><BOLD>Notifications</BOLD></GridCell>
+    <GridCell md={3}><BOLD>View all APIs</BOLD></GridCell>
+  </Row>
+</Container>
+
+## Join the community
+
+See the source code, connect with others, and get connected.

--- a/docs/ui/components/home/GridCell.tsx
+++ b/docs/ui/components/home/GridCell.tsx
@@ -1,17 +1,20 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
+import { Interpolation } from '@emotion/serialize';
 import { borderRadius, theme } from '@expo/styleguide';
-import React from 'react';
-import { Col } from 'react-grid-system';
+import React, { PropsWithChildren } from 'react';
+import { Col, ColProps } from 'react-grid-system';
 
-type GridCellProps = {
-  children: any;
-  style: SerializedStyles;
-  [props: string]: any;
+type GridCellProps = ColProps & {
+  style?: SerializedStyles | Interpolation<Theme>;
 };
 
-export const GridCell = ({ children, style, md }: GridCellProps) => (
+export const GridCell = ({
+  children,
+  md,
+  style = gridCellDefaultStyle,
+}: PropsWithChildren<GridCellProps>) => (
   <Col css={gridCellWrapperStyle} md={md}>
-    <div css={[gridCellStyle, style, !style && gridCellDefaultStyle]}>{children}</div>
+    <div css={[gridCellStyle, style]}>{children}</div>
   </Col>
 );
 

--- a/docs/ui/components/home/GridCell.tsx
+++ b/docs/ui/components/home/GridCell.tsx
@@ -1,0 +1,35 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { borderRadius, theme } from '@expo/styleguide';
+import React from 'react';
+import { Col } from 'react-grid-system';
+
+type GridCellProps = {
+  children: any;
+  style: SerializedStyles;
+  [props: string]: any;
+};
+
+export const GridCell = ({ children, style, md }: GridCellProps) => (
+  <Col css={gridCellWrapperStyle} md={md}>
+    <div css={[gridCellStyle, style, !style && gridCellDefaultStyle]}>{children}</div>
+  </Col>
+);
+
+const gridCellWrapperStyle = css`
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+`;
+
+const gridCellStyle = {
+  borderRadius: borderRadius.large,
+  margin: 16,
+  padding: 16,
+  minHeight: 200,
+};
+
+const gridCellDefaultStyle = {
+  backgroundColor: theme.background.secondary,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: theme.border.default,
+};

--- a/docs/ui/components/home/GridCell.tsx
+++ b/docs/ui/components/home/GridCell.tsx
@@ -1,38 +1,85 @@
-import { css, SerializedStyles, Theme } from '@emotion/react';
-import { Interpolation } from '@emotion/serialize';
+import { css, SerializedStyless } from '@emotion/react';
 import { borderRadius, theme } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 import { Col, ColProps } from 'react-grid-system';
 
+import { Link } from '~/ui/components/link';
+import { fontStacks } from '~/ui/foundations/typography';
+
 type GridCellProps = ColProps & {
-  style?: SerializedStyles | Interpolation<Theme>;
+  style?: SerializedStyles;
 };
 
-export const GridCell = ({
-  children,
-  md,
-  style = gridCellDefaultStyle,
-}: PropsWithChildren<GridCellProps>) => (
-  <Col css={gridCellWrapperStyle} md={md}>
-    <div css={[gridCellStyle, style]}>{children}</div>
+type APIGridCellProps = GridCellProps & {
+  icon?: string;
+  title?: string;
+  link?: string;
+};
+
+export const GridCell = ({ children, md, style = {} }: PropsWithChildren<GridCellProps>) => (
+  <Col css={cellWrapperStyle} md={md}>
+    <div css={[cellStyle, style]}>{children}</div>
   </Col>
 );
 
-const gridCellWrapperStyle = css`
+export const APIGridCell = ({ md, icon, title, link, style = {} }: APIGridCellProps) => (
+  <Col css={cellWrapperStyle} md={md}>
+    <div css={[cellStyle, cellAPIStyle, style]}>
+      <>
+        <div css={cellIconWrapperStyle}>{icon}</div>
+        {title && link && (
+          <div css={cellTitleWrapperStyle}>
+            <Link href={link} css={cellTitleStyle}>
+              {title}
+              <span css={cellTitleArrow}>{'->'}</span>
+            </Link>
+          </div>
+        )}
+      </>
+    </div>
+  </Col>
+);
+
+const cellWrapperStyle = css`
   padding-left: 0 !important;
   padding-right: 0 !important;
 `;
 
-const gridCellStyle = {
+const cellStyle = css({
   borderRadius: borderRadius.large,
   margin: 16,
-  padding: 16,
+  padding: 32,
   minHeight: 200,
-};
+});
 
-const gridCellDefaultStyle = {
+const cellAPIStyle = css({
   backgroundColor: theme.background.secondary,
   borderWidth: 1,
   borderStyle: 'solid',
   borderColor: theme.border.default,
-};
+  padding: 0,
+  overflow: 'hidden',
+});
+
+const cellIconWrapperStyle = css({
+  display: 'flex',
+  minHeight: 136,
+  justifyContent: 'space-around',
+  alignItems: 'center',
+});
+
+const cellTitleWrapperStyle = css({
+  display: 'flex',
+  backgroundColor: theme.background.default,
+  padding: 16,
+});
+
+const cellTitleStyle = css({
+  fontSize: 15,
+  fontFamily: fontStacks.bold,
+  lineHeight: '30px',
+  color: theme.text.default,
+  textDecoration: 'none',
+});
+
+const cellTitleArrow = css({ float: 'right', fontSize: 18, color: theme.text.secondary });

--- a/docs/ui/components/home/GridCell.tsx
+++ b/docs/ui/components/home/GridCell.tsx
@@ -1,14 +1,21 @@
-import { css, SerializedStyless } from '@emotion/react';
-import { borderRadius, theme } from '@expo/styleguide';
+import { css, SerializedStyles } from '@emotion/react';
+import { borderRadius, theme, colors } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 import { Col, ColProps } from 'react-grid-system';
 
 import { Link } from '~/ui/components/link';
+import { P } from '~/ui/components/text';
 import { fontStacks } from '~/ui/foundations/typography';
 
 type GridCellProps = ColProps & {
   style?: SerializedStyles;
 };
+
+export const GridCell = ({ children, md, style }: PropsWithChildren<GridCellProps>) => (
+  <Col css={cellWrapperStyle} md={md}>
+    <div css={[cellStyle, style]}>{children}</div>
+  </Col>
+);
 
 type APIGridCellProps = GridCellProps & {
   icon?: string;
@@ -16,26 +23,45 @@ type APIGridCellProps = GridCellProps & {
   link?: string;
 };
 
-export const GridCell = ({ children, md, style = {} }: PropsWithChildren<GridCellProps>) => (
+export const APIGridCell = ({ md, icon, title, link, style }: APIGridCellProps) => (
   <Col css={cellWrapperStyle} md={md}>
-    <div css={[cellStyle, style]}>{children}</div>
+    <div css={[cellStyle, cellAPIStyle, style]}>
+      <div css={cellIconWrapperStyle}>{icon}</div>
+      <div css={cellTitleWrapperStyle}>
+        <Link href={link} css={cellTitleStyle}>
+          {title}
+          <span css={cellTitleArrow}>{'->'}</span>
+        </Link>
+      </div>
+    </div>
   </Col>
 );
 
-export const APIGridCell = ({ md, icon, title, link, style = {} }: APIGridCellProps) => (
+type CommunityGridCellProps = APIGridCellProps & {
+  description?: string;
+  iconBackground?: string;
+};
+
+export const CommunityGridCell = ({
+  md,
+  icon,
+  iconBackground = colors.gray['800'],
+  title,
+  link,
+  description,
+  style,
+}: CommunityGridCellProps) => (
   <Col css={cellWrapperStyle} md={md}>
-    <div css={[cellStyle, cellAPIStyle, style]}>
-      <>
-        <div css={cellIconWrapperStyle}>{icon}</div>
-        {title && link && (
-          <div css={cellTitleWrapperStyle}>
-            <Link href={link} css={cellTitleStyle}>
-              {title}
-              <span css={cellTitleArrow}>{'->'}</span>
-            </Link>
-          </div>
-        )}
-      </>
+    <div css={[cellCommunityStyle, style]}>
+      <div css={[cellCommunityIconWrapperStyle, css({ backgroundColor: iconBackground })]}>
+        {icon}
+      </div>
+      <div>
+        <Link href={link} css={cellCommunityTitleStyle}>
+          {title}
+        </Link>
+        <P css={cellCommunityDescriptionStyle}>{description}</P>
+      </div>
     </div>
   </Col>
 );
@@ -82,3 +108,29 @@ const cellTitleStyle = css({
 });
 
 const cellTitleArrow = css({ float: 'right', fontSize: 18, color: theme.text.secondary });
+
+const cellCommunityStyle = css({
+  display: 'flex',
+  margin: 16,
+  flexDirection: 'row',
+});
+
+const cellCommunityIconWrapperStyle = css({
+  height: 32,
+  width: 32,
+  display: 'flex',
+  justifyContent: 'space-around',
+  alignItems: 'center',
+  borderRadius: borderRadius.large,
+  marginRight: 16,
+});
+
+const cellCommunityTitleStyle = css({
+  fontSize: 16,
+  fontFamily: fontStacks.bold,
+  color: theme.text.default,
+  textDecoration: 'none',
+  marginBottom: 8,
+});
+
+const cellCommunityDescriptionStyle = css({ color: theme.text.secondary, marginTop: 4 });

--- a/docs/ui/components/home/GridCell.tsx
+++ b/docs/ui/components/home/GridCell.tsx
@@ -69,7 +69,6 @@ const cellIconWrapperStyle = css({
 });
 
 const cellTitleWrapperStyle = css({
-  display: 'flex',
   backgroundColor: theme.background.default,
   padding: 16,
 });

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7102,6 +7102,13 @@ react-feather@^2.0.9:
   dependencies:
     prop-types "^15.7.2"
 
+react-grid-system@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/react-grid-system/-/react-grid-system-7.3.1.tgz#034ad701ec894ba7a7eb0a4bd715d83be08c598b"
+  integrity sha512-q5dTeKURLZ2lAFLTjMKdjgubhibIu+EvdT838bcki/rQ8ftJGm+afzZHT2Da6BASWYpXo9+OSIS9M7VFp4/gbQ==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-is@16.13.1, react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
# Why

* https://linear.app/expo/issue/ENG-1716

# How

This PR adds the skeleton for the new Home page as well as the new grid system (`react-grid-system`) for the Home page tiles.

@byCedric Also, as I posted some time on the Discord, it would be nice to migrate all the docs pages to use `mdx` extension. This allow editors to parse and highlight JSX inside Markdown files correctly and overall improves DX. So, with the new Home page I have started naming new files with `.mdx` extension. :wink:

# Test Plan

* http://localhost:3002/test-design/home/

# Preview

### Full Window
<img width="1153" alt="Screenshot 2021-08-09 at 23 24 15" src="https://user-images.githubusercontent.com/719641/128777695-66d12e82-8675-4ca0-ae32-2492c18327dc.png">

### Mobile
<img width="498" alt="Screenshot 2021-08-09 at 23 24 32" src="https://user-images.githubusercontent.com/719641/128777658-43f22b72-26b2-4fa9-a9b7-078cb62df223.png">
