### PR TITLE
[docs] fix warnings related to the `Table` components

### DIFF
--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -6,13 +6,10 @@ import { TextAlign } from '~/ui/components/Table/Table.shared';
 
 type HeaderCellProps = {
   textAlign?: TextAlign;
-  key?: string | number;
 };
 
-export const HeaderCell = ({ children, textAlign, key }: PropsWithChildren<HeaderCellProps>) => (
-  <th key={key} css={[tableHeadersCellStyle, textAlign && { textAlign }]}>
-    {children}
-  </th>
+export const HeaderCell = ({ children, textAlign }: PropsWithChildren<HeaderCellProps>) => (
+  <th css={[tableHeadersCellStyle, textAlign && { textAlign }]}>{children}</th>
 );
 
 const tableHeadersCellStyle = css({

--- a/docs/ui/components/Table/Row.tsx
+++ b/docs/ui/components/Table/Row.tsx
@@ -15,7 +15,7 @@ const tableRowStyle = css({
   '&:last-child': {
     borderWidth: 0,
   },
-  '&:nth-child(2n)': {
+  '&:nth-of-type(2n)': {
     backgroundColor: theme.background.secondary,
   },
 });

--- a/docs/ui/components/Table/TableHead.tsx
+++ b/docs/ui/components/Table/TableHead.tsx
@@ -13,7 +13,9 @@ export const TableHead = ({ headers, headersAlign }: TableHeadProps) => (
   <thead>
     <Row>
       {headers.map((header, i) => (
-        <HeaderCell key={i} textAlign={(headersAlign && headersAlign[i]) || TextAlign.Left}>
+        <HeaderCell
+          key={`table-header-${i}`}
+          textAlign={(headersAlign && headersAlign[i]) || TextAlign.Left}>
           {header}
         </HeaderCell>
       ))}


### PR DESCRIPTION
# Why & How

This PR fixes warnings  related to the `Table` components, appearing in the console while in DEV mode.

* > Warning: HeaderCell: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
* > The pseudo class ":nth-child" is potentially unsafe when doing server-side rendering. Try changing it to ":nth-of-type". 

# Test Plan

Change have been tested by running docs website on `localhost` and verified using `test-design` page.

