### PR TITLE
[docs] fix minor UI issues, use empty string as default title for code blocks

### DIFF
--- a/docs/pages/test-design/index.mdx
+++ b/docs/pages/test-design/index.mdx
@@ -67,6 +67,14 @@ This is some cool CSS.
 }
 ```
 
+No language specified.
+
+```
+{
+  hello: "json"
+}
+```
+
 ### Installing Expo CLI
 
 <!-- <Terminal

--- a/docs/ui/components/Markdown/Components.tsx
+++ b/docs/ui/components/Markdown/Components.tsx
@@ -1,5 +1,5 @@
 import { css, CSSObject } from '@emotion/react';
-import { colors } from '@expo/styleguide';
+import { theme } from '@expo/styleguide';
 import React from 'react';
 
 import { Blockquote } from './Blockquote';
@@ -81,7 +81,11 @@ const markdownStyles: MarkdownConfigType = {
   },
   hr: {
     Component: 'hr',
-    style: { border: 'none', borderTop: `1px solid ${colors.gray[400]}`, margin: `2ch 0` },
+    style: {
+      border: 'none',
+      borderTop: `1px solid ${theme.border.default}`,
+      margin: `16px 0 24px`,
+    },
   },
   blockquote: {
     Component: Blockquote,

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -26,6 +26,7 @@ const headerStyle = css`
   border-top-right-radius: ${borderRadius.medium}px;
   display: flex;
   justify-content: space-between;
+  min-height: 42px;
 `;
 
 const headerDarkStyle = css`
@@ -34,7 +35,8 @@ const headerDarkStyle = css`
 `;
 
 const headerTitleStyle = css`
-  padding: 0.625rem 1rem;
+  padding: 0 1rem;
+  line-height: 42px;
 `;
 
 const headerActionsStyle = css`

--- a/docs/ui/components/Snippet/blocks/Code.tsx
+++ b/docs/ui/components/Snippet/blocks/Code.tsx
@@ -20,7 +20,7 @@ type CodeProps = PropsWithChildren<{
 // - [ ] Hide code that isn't relevant using `@hide <placeholder> ... @end`
 // - [ ] Annotate/mark code with tooltip popover
 
-export const Code = ({ children, className, title = 'JavaScript' }: CodeProps) => {
+export const Code = ({ children, className, title = '' }: CodeProps) => {
   const textChildren = children?.toString() || '';
   const mdxLanguage = (className || '').split(' ')[0]; // TODO(cedric): clean this up
 

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -8,5 +8,7 @@ type CellProps = {
 };
 
 export const Cell = ({ children, textAlign }: PropsWithChildren<CellProps>) => (
-  <td css={css({ borderBottom: 0, verticalAlign: 'middle', textAlign })}>{children}</td>
+  <td css={css({ borderBottom: 0, verticalAlign: 'middle', wordBreak: 'break-word', textAlign })}>
+    {children}
+  </td>
 );


### PR DESCRIPTION
# Why & how

This PR fixes few minor UI issues:
* `<hr />` border being not theme related
* word break in table cells to prevent overflow on mobile

It also introduces the change to the `Code` component, now the default title is an empty string instead of 'JavaScript', which I have found quite confusing on pages like this, when all the code block were titled like that:
 * https://docs.expo.dev/distribution/publishing-websites/ (see image below for the preview after changes)

But changing title to and empty string required a few style changes to prevent the header shrinking vertically. I have also added an example like that to the `test-design` page.

# Test Plan

The changes have been tested by running docs website on `localhost`.

# Preview
<img width="1142" alt="Screenshot 2021-10-18 at 15 22 06" src="https://user-images.githubusercontent.com/719641/137740134-2b783875-7085-43ab-87a8-c5b48a4fc0cf.png">


